### PR TITLE
feat: track heap timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ If you start your application like this:
 node -r @nearform/heap-profiler index.js
 ```
 
-Then you will be able to generate a heap profile and heap snapshot by sending the process a SIGUSR2 signal, like this:
+Then you will be able make a snapshot, start profiling heap, and start tracking allocation timeline by sending the process a SIGUSR2 signal, like this:
 
 ```
 kill -USR2 $PID
 ```
+
+Heap snapshot will be immediately available, heap profile will be done after the specified duration (10s by default).
+Allocation timeline must be stopped, by sending another SIGUSR2 signal to the process.
+Then the tool will await on the next signal, to resume profiling/tracking/shooting the heap. 
 
 The preloader uses the following environment variables to control its behavior:
 
@@ -41,9 +45,16 @@ The preloader uses the following environment variables to control its behavior:
 - `HEAP_PROFILER_PROFILE`: If set to `false`, it will not generate heap sampling profile.
 
 - `HEAP_PROFILER_PROFILE_DESTINATION`: The path where to store the profile. The default will be a `.heapprofile` in the current directory.
+
 - `HEAP_PROFILER_PROFILE_INTERVAL`: Heap sampling profile interval, in bytes. Default is `32768` (32KB).
 
 - `HEAP_PROFILER_PROFILE_DURAITON`: Heap sampling profile in milliseconds. Default is `10000` (10 seconds).
+
+- `HEAP_PROFILER_TIMELINE`: If set to `false`, it will not start tracking timeline allocation.
+
+- `HEAP_PROFILER_TIMELINE_DESTINATION`: The path where to store the allocation timeline. The default will be a `.heaptimeline` in the current directory.
+
+- `HEAP_PROFILER_TIMELINE_RUN_GC`: Whether or not running Garbage Collector before and after the allocation timeline, to see only remaining objects (default to false).
 
 ## API
 
@@ -53,16 +64,36 @@ The promise resolved value (or the callback argument) will be the generated file
 
 The available functions are:
 
-- `generateHeapSnapshot([options], [callback])`: Generates a heap dump
+- `generateHeapSnapshot([options], [callback]): [Promise]`: Generates a heap dump
 
   - `destination`: The path where to store the snapshot. The default will be a `.heapsnapshot` in the current directory.
   - `runGC`: If to run the garbage collector before taking the snapshot. The default is `false` and it is ignored if the process is not started with the `--expose-gc` flag.
 
-- `generateHeapSamplingProfile([options], [callback])`: Generates a heap sampling profiler. The valid options are:
+- `generateHeapSamplingProfile([options], [callback]): [Promise]`: Generates a heap sampling profiler. The valid options are:
 
   - `destination`: The path where to store the profile. The default will be a `.heapprofile` in the current directory.
   - `interval`: Sample interval, in bytes. Default is `32768` (32KB).
   - `duration`: Sample duration, in milliseconds. Default is `10000` (10 seconds).
+
+- `recordAllocationTimeline([options], [callback]): [function|Promise]`: Starts recording allocation on heap. The valid options are:
+
+  - `destination`: The path where to store the timeline. The default will be a `.heaptimeline` in the current directory.
+  - `runGC`: If to run the garbage collector at the begining and the end of the timeline. The default is `false` and it is ignored if the process is not started with the `--expose-gc` flag.
+
+   When using callback-style, call the returned function to stop recording allocation, and generate the output file: 
+   ```js
+   const stop = recordAllocationTimeline(options, (err) => { /* handle start errors */ })
+   // later on...
+   stop((err) => { /* handle stop errors, and use the file */ })
+   ```
+   When using promise-style, the returned promise will resolve with an async function for the same purposes:
+   ```js
+   const stop = await recordAllocationTimeline(options)
+   // catch any start error
+   // later on...
+   await stop()
+   // catch any stop errors, and use the file
+   ```
 
 ## Performance impact
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "@nearform/heap-profiler",
   "version": "0.4.0",
-  "description": "Heap dump and sample profiler generator for Node.",
+  "description": "Heap dump, sample profiler and allocation timeline generator for Node.",
   "author": "NearForm Ltd",
   "homepage": "https://github.com/nearform/heap-profiler",
   "contributors": [
     {
       "name": "Paolo Insogna",
       "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "Damien Simonin Feugas",
+      "url": "https://github.com/feugy"
     }
   ],
   "license": "Apache-2.0",
@@ -21,7 +25,9 @@
     "heap",
     "profile",
     "sampling",
-    "snapshot"
+    "snapshot",
+    "allocation",
+    "timeline"
   ],
   "repository": {
     "type": "git",
@@ -36,7 +42,7 @@
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint src/**/*.js test/**/*.js",
     "test": "tap --gc --reporter=spec --coverage-report=html --coverage-report=text --no-browser test/*.spec.js",
-    "ci": "npm run lint && tap --gc --no-color --reporter=spec --coverage-report=json --coverage-report=text --branches 90 --functions 90 --lines 90 --statements 90 test/*.spec.js"
+    "ci": "npm run lint && tap --gc --no-color --reporter=spec --coverage-report=json --coverage-report=text --branches 90 --functions 90 --lines 90 --statements 90 --timeout 45 test/*.spec.js"
   },
   "dependencies": {
     "sonic-boom": "^1.0.1"

--- a/src/preloader.js
+++ b/src/preloader.js
@@ -2,8 +2,7 @@
 
 const generateHeapSnapshot = require('./snapshot')
 const generateHeapSamplingProfile = require('./profile')
-
-let working = false
+const recordAllocationTimeline = require('./timeline')
 
 async function benchmarkGeneration(logger, type, report, options) {
   const start = process.hrtime.bigint()
@@ -15,20 +14,16 @@ async function benchmarkGeneration(logger, type, report, options) {
 }
 
 module.exports = function installPreloader(logger) {
-  process.on('SIGUSR2', () => {
-    if (working) {
-      logger.info('[@nearform/heap-profile] Received SIGUSR2 but generation is already happening. Doing nothing.')
-      return
-    }
-
-    working = true
+  function runTools() {
     logger.info('[@nearform/heap-profile] Received SIGUSR2. Generating heap reports ...')
 
     const takeSnapshot = process.env.HEAP_PROFILER_SNAPSHOT !== 'false'
     const takeProfile = process.env.HEAP_PROFILER_PROFILE !== 'false'
+    const recordTimeline = process.env.HEAP_PROFILER_TIMELINE !== 'false'
 
     const snapshotOptions = {}
     const profilerOptions = {}
+    const timelineOptions = {}
 
     if ('HEAP_PROFILER_SNAPSHOT_DESTINATION' in process.env) {
       snapshotOptions.destination = process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION
@@ -50,6 +45,14 @@ module.exports = function installPreloader(logger) {
       profilerOptions.duration = parseInt(process.env.HEAP_PROFILER_PROFILE_DURATION, 10)
     }
 
+    if ('HEAP_PROFILER_TIMELINE_DESTINATION' in process.env) {
+      timelineOptions.destination = process.env.HEAP_PROFILER_TIMELINE_DESTINATION
+    }
+
+    if ('HEAP_PROFILER_TIMELINE_RUN_GC' in process.env) {
+      timelineOptions.runGC = process.env.HEAP_PROFILER_TIMELINE_RUN_GC === 'true'
+    }
+
     const promises = []
 
     if (takeSnapshot) {
@@ -60,15 +63,27 @@ module.exports = function installPreloader(logger) {
       promises.push(benchmarkGeneration(logger, 'sampling profile', generateHeapSamplingProfile, profilerOptions))
     }
 
+    if (recordTimeline) {
+      promises.push(benchmarkGeneration(logger, 'allocation timeline', async options => {
+        const stop = await recordAllocationTimeline(options)
+        logger.info('[@nearform/heap-profile] Allocation timeline started. Awaiting SIGUSR2 to stop ...')
+        return new Promise((resolve, reject) => process.once('SIGUSR2', () => stop().then(resolve).catch(reject)))
+      }, timelineOptions))
+    }
+
     Promise.all(promises)
-      .then(files => {
+      .then(() => {
         logger.info('[@nearform/heap-profile] Generation completed.')
+        // resume awaiting on the next start signal
+        process.once('SIGUSR2', runTools)
       })
       .catch(e => {
         logger.error('[@nearform/heap-profile] Generation failed.', e)
+        // stops itslef
+        process.kill(process.pid, 'SIGUSR2')
       })
-      .finally(() => (working = false))
-  })
+  }
 
+  process.once('SIGUSR2', runTools)
   logger.info(`[@nearform/heap-profile] Listening for SIGUSR2 signal on process ${process.pid}.`)
 }

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const { Session } = require('inspector')
+const SonicBoom = require('sonic-boom')
+const { ensurePromiseCallback, destinationFile } = require('./utils')
+
+module.exports = function recordAllocationTimeline(options, cb) {
+  /* istanbul ignore if */
+  if (typeof options === 'function') {
+    cb = options
+    options = null
+  }
+
+  // Prepare the context
+  const [startCb, startPromise] = ensurePromiseCallback(cb)
+  const { destination, runGC } = Object.assign({ destination: destinationFile('heaptimeline'), runGC: true }, options)
+  const session = new Session()
+
+  if (typeof destination !== 'string' || destination.length === 0) {
+    throw new Error('The destination option must be a non empty string')
+  }
+
+  function handleStop(stopCb) {
+    // stop functon used in callback-style
+    const writer = new SonicBoom({ dest: destination })
+    let error = null
+    let handled = false
+
+    writer.on('error', err => {
+      /* istanbul ignore if */
+      if (handled) {
+        return
+      }
+      handled = true
+      session.disconnect()
+      stopCb(err)
+    })
+
+    writer.on('close', () => {
+      /* istanbul ignore if */
+      if (handled) {
+        return
+      }
+      handled = true
+      session.disconnect()
+      stopCb(error, destination)
+    })
+
+    try {
+      // Prepare chunk appending
+      session.on('HeapProfiler.addHeapSnapshotChunk', m => {
+        // A write failed, discard all the rest
+        /* istanbul ignore if */
+        if (error) {
+          return
+        }
+        try {
+          writer.write(m.params.chunk)
+        } catch (e) {
+          /* istanbul ignore next */
+          error = e
+        }
+      })
+      if (runGC && typeof global.gc === 'function') {
+        global.gc()
+      }
+      session.post('HeapProfiler.stopTrackingHeapObjects', null, err => {
+        /* istanbul ignore if */
+        if (err) {
+          error = err
+        }
+        writer.end()
+      })
+    } catch (err) {
+      error = err
+      writer.end()
+    }
+  }
+  // Start the session
+  session.connect()
+  // Trigger GC and start start tracking allocations on heap
+  if (runGC && typeof global.gc === 'function') {
+    global.gc()
+  }
+  session.post('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true }, err => {
+    /* istanbul ignore if */
+    if (err) {
+      return startCb(err)
+    }
+    if (startPromise) {
+      // when using promise-style, we need to wrap handleStop in a promise
+      startCb(null, function() {
+        return new Promise(function(resolve, reject) {
+          handleStop(err => {
+            err ? reject(err) : resolve()
+          })
+        })
+      })
+    }
+  })
+
+  // when using callback-style, startPromise will be undefined
+  return startPromise || handleStop
+}

--- a/test/fixtures/snapshotSchema.js
+++ b/test/fixtures/snapshotSchema.js
@@ -96,7 +96,7 @@ const snapshot = {
     },
     trace_tree: {
       type: 'array',
-      items: { type: 'number' }
+      items: { type: ['number', 'array'] }
     },
     samples: {
       type: 'array',

--- a/test/snapshot.spec.js
+++ b/test/snapshot.spec.js
@@ -15,8 +15,8 @@ t.test('it correctly generates a snapshot using promises', async t => {
 
   const generated = JSON.parse(readFileSync(destination, 'utf-8'))
 
-  t.true(validate(generated))
-
+  validate(generated)
+  t.strictSame(validate.errors, null)
   cleanup()
 })
 
@@ -29,7 +29,8 @@ t.test('it correctly generates a snapshot using callbacks', async t => {
         const generated = JSON.parse(readFileSync(destination, 'utf-8'))
         cleanup()
 
-        t.true(validate(generated))
+        validate(generated)
+        t.strictSame(validate.errors, null)
         resolve()
       } catch (e) {
         reject(e)
@@ -47,7 +48,8 @@ t.test('it runs the garbage collector if requested to', async t => {
 
   const generated = JSON.parse(readFileSync(destination, 'utf-8'))
 
-  t.true(validate(generated))
+  validate(generated)
+  t.strictSame(validate.errors, null)
   t.equal(gcStub.callCount, 1)
   cleanup()
 

--- a/test/timeline.spec.js
+++ b/test/timeline.spec.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const t = require('tap')
+const { readFileSync } = require('fs')
+const { file: tmpFile } = require('tmp-promise')
+const { stub } = require('sinon')
+
+const recordAllocationTimeline = require('../src/timeline')
+const validate = require('./fixtures/snapshotSchema')
+const wait = require('util').promisify(setTimeout)
+const duration = 10
+const timeout = 5000
+
+t.test('it correctly generates a timeline using promises', { timeout }, async t => {
+  const { path: destination, cleanup } = await tmpFile()
+
+  const stop = await recordAllocationTimeline({ destination })
+  await wait(duration)
+  await stop()
+
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  validate(generated)
+  t.strictSame(validate.errors, null)
+  cleanup()
+})
+
+t.test('it correctly generates a timeline using callbacks', { timeout }, async t => {
+  const { path: destination, cleanup } = await tmpFile()
+
+  return new Promise((resolve, reject) => {
+    const stop = recordAllocationTimeline({ destination }, (err) => {
+      if (err) {
+        return reject(err)
+      }
+    })
+    setTimeout(() => stop((err) => {
+      if (err) {
+        return reject(err)
+      }
+      try {
+        const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+        cleanup()
+        validate(generated)
+        t.strictSame(validate.errors, null)
+        resolve()
+      } catch (e) {
+        reject(e)
+      }
+    }), duration)
+  })
+})
+
+t.test('it runs the garbage collector if requested to', { timeout }, async t => {
+  const gcStub = stub(global, 'gc')
+
+  const { path: destination, cleanup } = await tmpFile()
+
+  const stop = await recordAllocationTimeline({ destination, runGC: true })
+  await wait(duration)
+  await stop()
+
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  validate(generated)
+  t.strictSame(validate.errors, null)
+  t.equal(gcStub.callCount, 2)
+  cleanup()
+
+  gcStub.restore()
+})
+
+t.test('it handles garbage collector error before recording', async t => {
+  const gcStub = stub(global, 'gc')
+  gcStub.onFirstCall().throws(new Error('FAILED'))
+  const { path: destination, cleanup } = await tmpFile()
+
+  try {
+    await recordAllocationTimeline({ destination, runGC: true })
+    t.fail('DID NOT THROW')
+  } catch (e) {
+    t.equal(e.message, 'FAILED')
+  }
+
+  t.equal(gcStub.callCount, 1)
+  cleanup()
+
+  gcStub.restore()
+})
+
+t.test('it handles garbage collector error when stopping recording', async t => {
+  const gcStub = stub(global, 'gc')
+  gcStub.onSecondCall().throws(new Error('FAILED'))
+  const { path: destination, cleanup } = await tmpFile()
+
+  const stop = await recordAllocationTimeline({ destination, runGC: true })
+  await wait(duration)
+  try {
+    await stop()
+    t.fail('DID NOT THROW')
+  } catch (e) {
+    t.equal(e.message, 'FAILED')
+  }
+
+  t.equal(gcStub.callCount, 2)
+  cleanup()
+
+  gcStub.restore()
+})
+
+t.test('it handles file saving errors using promises', async t => {
+  const stop = await recordAllocationTimeline({ destination: '/this/doesnt/exists' })
+  await t.rejects(stop, {
+    message: "ENOENT: no such file or directory, open '/this/doesnt/exists'"
+  })
+})
+
+t.test('it handles file saving errors using callbacks', t => {
+  const stop = recordAllocationTimeline({ destination: '/this/doesnt/exists' }, err => {
+    t.fail(err)
+  })
+  stop(err => {
+    t.equal(err.message, "ENOENT: no such file or directory, open '/this/doesnt/exists'")
+    t.end()
+  })
+})
+
+t.test('it validates the destination option', t => {
+  t.throws(() => recordAllocationTimeline({ destination: 1 }), 'The destination option must be a non empty string')
+  t.throws(() => recordAllocationTimeline({ destination: '' }), 'The destination option must be a non empty string')
+  t.end()
+})


### PR DESCRIPTION
#### What's in there?

- [x] new tool to record heap allocation timeline: `recordAllocationTimeline()`
- [x] new env variables: `HEAP_PROFILER_TIMELINE`, `HEAP_PROFILER_TIMELINE_DESTINATION`, `HEAP_PROFILER_TIMELINE_RUN_GC`, to control it, along with SIGUSR2, now used to start and stop it.

#### How to test?

Given some `test.js` script you'd like to profile, use the variable above to enable/disable allocation tracking, and send SIGUSR2, once to start, once to stop.
Then open the `.heaptimeline` file with Chrome DevTools.