### PR TITLE
fix: Anticipate destination validation and use callback-style preloader.

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -2,7 +2,7 @@
 
 const { Session } = require('inspector')
 const SonicBoom = require('sonic-boom')
-const { ensurePromiseCallback, destinationFile } = require('./utils')
+const { ensurePromiseCallback, destinationFile, validateDestinationFile } = require('./utils')
 
 module.exports = function recordAllocationTimeline(options, cb) {
   /* istanbul ignore if */
@@ -21,84 +21,101 @@ module.exports = function recordAllocationTimeline(options, cb) {
   }
 
   function handleStop(stopCb) {
+    // Trigger GC and start start tracking allocations on heap
+    /* istanbul ignore else */
+    if (runGC && typeof global.gc === 'function') {
+      try {
+        global.gc()
+      } catch (e) {
+        session.disconnect()
+        return stopCb(e)
+      }
+    }
+
     // stop functon used in callback-style
     const writer = new SonicBoom({ dest: destination })
     let error = null
     let handled = false
 
-    writer.on('error', err => {
+    function onWriterEnd(err) {
       /* istanbul ignore if */
       if (handled) {
         return
       }
+
       handled = true
       session.disconnect()
-      stopCb(err)
-    })
 
-    writer.on('close', () => {
-      /* istanbul ignore if */
-      if (handled) {
-        return
-      }
-      handled = true
-      session.disconnect()
-      stopCb(error, destination)
-    })
-
-    try {
-      // Prepare chunk appending
-      session.on('HeapProfiler.addHeapSnapshotChunk', m => {
-        // A write failed, discard all the rest
-        /* istanbul ignore if */
-        if (error) {
-          return
-        }
-        try {
-          writer.write(m.params.chunk)
-        } catch (e) {
-          /* istanbul ignore next */
-          error = e
-        }
-      })
-      if (runGC && typeof global.gc === 'function') {
-        global.gc()
-      }
-      session.post('HeapProfiler.stopTrackingHeapObjects', null, err => {
-        /* istanbul ignore if */
-        if (err) {
-          error = err
-        }
-        writer.end()
-      })
-    } catch (err) {
-      error = err
-      writer.end()
+      stopCb(err || error, destination)
     }
+
+    writer.on('error', onWriterEnd)
+    writer.on('close', onWriterEnd)
+
+    // Prepare chunk appending
+    session.on('HeapProfiler.addHeapSnapshotChunk', m => {
+      // A write failed, discard all the rest
+      /* istanbul ignore if */
+      if (error) {
+        return
+      }
+
+      try {
+        writer.write(m.params.chunk)
+      } catch (e) {
+        /* istanbul ignore next */
+        error = e
+      }
+    })
+
+    // Stop tracking
+    session.post('HeapProfiler.stopTrackingHeapObjects', err => {
+      /* istanbul ignore if */
+      if (err) {
+        error = err
+      }
+
+      writer.end()
+    })
   }
-  // Start the session
-  session.connect()
-  // Trigger GC and start start tracking allocations on heap
-  if (runGC && typeof global.gc === 'function') {
-    global.gc()
-  }
-  session.post('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true }, err => {
-    /* istanbul ignore if */
+
+  validateDestinationFile(destination, err => {
     if (err) {
       return startCb(err)
     }
-    if (startPromise) {
-      // when using promise-style, we need to wrap handleStop in a promise
-      startCb(null, function() {
-        return new Promise(function(resolve, reject) {
-          handleStop(err => {
-            err ? reject(err) : resolve()
+
+    // Trigger GC and start start tracking allocations on heap
+    /* istanbul ignore else */
+    if (runGC && typeof global.gc === 'function') {
+      try {
+        global.gc()
+      } catch (e) {
+        return startCb(e)
+      }
+    }
+
+    // Start the session
+    session.connect()
+
+    session.post('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true }, err => {
+      /* istanbul ignore if */
+      if (err) {
+        return startCb(err)
+      }
+
+      if (startPromise) {
+        // When using promise-style, we need to wrap handleStop in a promise
+        startCb(null, function() {
+          return new Promise(function(resolve, reject) {
+            handleStop(err => {
+              err ? reject(err) : resolve()
+            })
           })
         })
-      })
-    }
+      }
+    })
   })
 
-  // when using callback-style, startPromise will be undefined
+  // When using callback-style, startPromise will be undefined
   return startPromise || handleStop
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { open, close } = require('fs')
 const { join } = require('path')
 
 function ensurePromiseCallback(cb) {
@@ -30,4 +31,14 @@ function destinationFile(ext) {
   return join(process.cwd(), `profile-${process.pid}-${Date.now()}.${ext}`)
 }
 
-module.exports = { ensurePromiseCallback, destinationFile }
+function validateDestinationFile(file, cb) {
+  open(file, 'w', (err, fd) => {
+    if (err) {
+      return cb(err)
+    }
+
+    close(fd, cb)
+  })
+}
+
+module.exports = { ensurePromiseCallback, destinationFile, validateDestinationFile }

--- a/test/preloader.spec.js
+++ b/test/preloader.spec.js
@@ -142,6 +142,7 @@ t.test('it should run continuously', async t => {
   // Set preloader variables
   cleanEnvironment()
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = profileDestination
+  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_SNAPSHOT = 'false'
   process.env.HEAP_PROFILER_TIMELINE = 'false'
 

--- a/test/preloader.spec.js
+++ b/test/preloader.spec.js
@@ -20,6 +20,7 @@ function cleanEnvironment() {
     'HEAP_PROFILER_SNAPSHOT_RUN_GC',
     'HEAP_PROFILER_DESTINATION',
     'HEAP_PROFILER_SNAPSHOT_DESTINATION',
+    'HEAP_PROFILER_PROFILE',
     'HEAP_PROFILER_PROFILE_DESTINATION',
     'HEAP_PROFILER_PROFILE_DURATION',
     'HEAP_PROFILER_PROFILE_INTERVAL',
@@ -53,7 +54,7 @@ t.test('it correctly generates reports when receiving USR2 and stop the second t
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = snapshotDestination
   process.env.HEAP_PROFILER_SNAPSHOT_RUN_GC = 'true'
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = profileDestination
-  process.env.HEAP_PROFILER_PROFILE_DURATION = 10
+  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_PROFILE_INTERVAL = 32768
   process.env.HEAP_PROFILER_TIMELINE_DESTINATION = timelineDestination
   process.env.HEAP_PROFILER_TIMELINE_RUN_GC = 'true'
@@ -122,12 +123,11 @@ t.test('it correctly exclude reports based on environment variables', async t =>
 })
 
 t.test('it should run continuously', async t => {
-  cleanEnvironment()
-
-  // Set preloader variables
   const snapshotDestination = await tmpName()
+  const profileDestination = await tmpName()
 
   // Set preloader variables
+  cleanEnvironment()
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = snapshotDestination
   process.env.HEAP_PROFILER_PROFILE = 'false'
   process.env.HEAP_PROFILER_TIMELINE = 'false'
@@ -139,14 +139,52 @@ t.test('it should run continuously', async t => {
   await waitForReport(logger.info, 3, 10)
   t.equal(logger.info.callCount, 3)
 
+  // Set preloader variables
+  cleanEnvironment()
+  process.env.HEAP_PROFILER_PROFILE_DESTINATION = profileDestination
+  process.env.HEAP_PROFILER_SNAPSHOT = 'false'
+  process.env.HEAP_PROFILER_TIMELINE = 'false'
+
   // second snapshot
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 6, 10)
+  await waitForReport(logger.info, 3, 10)
 
   // Check the report was generated
-  t.equal(logger.info.callCount, 6)
+  t.equal(logger.info.callCount, 3)
+
+  try {
+    unlinkSync(snapshotDestination)
+    unlinkSync(profileDestination)
+  } catch (e) {
+    // No-op
+  }
+})
+
+t.test('it should run continuously even when all tools are disabled', async t => {
+  cleanEnvironment()
+
+  // Set preloader variables
+  process.env.HEAP_PROFILER_SNAPSHOT = 'false'
+  process.env.HEAP_PROFILER_PROFILE = 'false'
+  process.env.HEAP_PROFILER_TIMELINE = 'false'
+
+  // first snapshot
+  process.kill(process.pid, 'SIGUSR2')
+
+  // Wait for generators time to finish
+  await waitForReport(logger.info, 2, 10)
+  t.equal(logger.info.callCount, 2)
+
+  // second snapshot
+  process.kill(process.pid, 'SIGUSR2')
+
+  // Wait for generators time to finish
+  await waitForReport(logger.info, 4, 10)
+
+  // Check the report was generated
+  t.equal(logger.info.callCount, 4)
 })
 
 t.test('it correctly logs generation errors', async t => {
@@ -156,15 +194,15 @@ t.test('it correctly logs generation errors', async t => {
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = '/this/doesnt/exists-1'
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = '/this/doesnt/exists-2'
   process.env.HEAP_PROFILER_TIMELINE_DESTINATION = '/this/doesnt/exists-3'
-  process.env.HEAP_PROFILER_PROFILE_DURATION = 10
+  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_PROFILE_INTERVAL = 32768
 
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.error, 1, 10)
+  await waitForReport(logger.error, 3, 2)
 
   // Check the reports were not generated
-  t.equal(logger.info.callCount, 2)
-  t.equal(logger.error.callCount, 1)
+  t.equal(logger.info.callCount, 3)
+  t.equal(logger.error.callCount, 3)
 })

--- a/test/timeline.spec.js
+++ b/test/timeline.spec.js
@@ -109,17 +109,13 @@ t.test('it handles garbage collector error when stopping recording', async t => 
 })
 
 t.test('it handles file saving errors using promises', async t => {
-  const stop = await recordAllocationTimeline({ destination: '/this/doesnt/exists' })
-  await t.rejects(stop, {
+  await t.rejects(recordAllocationTimeline({ destination: '/this/doesnt/exists' }), {
     message: "ENOENT: no such file or directory, open '/this/doesnt/exists'"
   })
 })
 
 t.test('it handles file saving errors using callbacks', t => {
-  const stop = recordAllocationTimeline({ destination: '/this/doesnt/exists' }, err => {
-    t.fail(err)
-  })
-  stop(err => {
+  recordAllocationTimeline({ destination: '/this/doesnt/exists' }, err => {
     t.equal(err.message, "ENOENT: no such file or directory, open '/this/doesnt/exists'")
     t.end()
   })


### PR DESCRIPTION
This PR addresses two things:

1. Writability of destination file is made (via `fs.open`) BEFORE running the tool, since it might expensive and pointless.
2. It fixes a SIGSEGV introduced in Node 14 (which I haven't found the reason for) by rewriting the preloader to use callbacks instead of promises.