### PR TITLE
Make allocation time use AbortController

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Then you will be able make a snapshot, start profiling heap, and start tracking 
 kill -USR2 $PID
 ```
 
-Heap snapshot will be immediately available, heap profile will be done after the specified duration (10s by default).
-Allocation timeline must be stopped, by sending another SIGUSR2 signal to the process.
+Heap snapshot will be generated immediately.
+
+Heap sampling profiler and allocation timeline must be stopped, by sending another SIGUSR2 signal to the process.
+
 Then the tool will await on the next signal, to resume profiling/tracking/shooting the heap.
 
 The preloader uses the following environment variables to control its behavior:
@@ -47,8 +49,6 @@ The preloader uses the following environment variables to control its behavior:
 - `HEAP_PROFILER_PROFILE_DESTINATION`: The path where to store the profile. The default will be a `.heapprofile` in the current directory.
 
 - `HEAP_PROFILER_PROFILE_INTERVAL`: Heap sampling profile interval, in bytes. Default is `32768` (32KB).
-
-- `HEAP_PROFILER_PROFILE_DURATION`: Heap sampling profile in milliseconds. Default is `10000` (10 seconds).
 
 - `HEAP_PROFILER_TIMELINE`: If set to `false`, it will not start tracking timeline allocation.
 
@@ -75,7 +75,7 @@ The available functions are:
 
   - `destination`: The path where to store the profile. The default will be a `.heapprofile` in the current directory.
   - `interval`: Sample interval, in bytes. Default is `32768` (32KB).
-  - `duration`: Sample duration, in milliseconds. Default is `10000` (10 seconds).
+  - `duration`: Sample duration, in milliseconds. Default is `10000` (10 seconds), and it is ignored if `signal` is provided.
   - `signal`: the [AbortController](http://npm.im/abort-controller) `signal`.
 
 - `recordAllocationTimeline([options], [callback]): [function|Promise]`: Starts recording allocation on heap. The valid options are:

--- a/README.md
+++ b/README.md
@@ -71,45 +71,31 @@ The available functions are:
   - `destination`: The path where to store the snapshot. The default will be a `.heapsnapshot` in the current directory.
   - `runGC`: If to run the garbage collector before taking the snapshot. The default is `false` and it is ignored if the process is not started with the `--expose-gc` flag.
 
-- `generateHeapSamplingProfile([options], [callback]): [Promise]`: Generates a heap sampling profiler. The valid options are:
+- `generateHeapSamplingProfile([options], [callback]): [Promise]`: Starts generating a heap sampling profiler. The valid options are:
 
   - `destination`: The path where to store the profile. The default will be a `.heapprofile` in the current directory.
   - `interval`: Sample interval, in bytes. Default is `32768` (32KB).
   - `duration`: Sample duration, in milliseconds. Default is `10000` (10 seconds), and it is ignored if `signal` is provided.
-  - `signal`: the [AbortController](http://npm.im/abort-controller) `signal`.
+  - `signal`: The [AbortController](http://npm.im/abort-controller) `signal` to use to stop the operation.
 
-- `recordAllocationTimeline([options], [callback]): [function|Promise]`: Starts recording allocation on heap. The valid options are:
+  The function accepts a callback function, otherwise it returns a Promise. The resolved value (or the callback argument) will be
+  the generated file path.
+
+- `recordAllocationTimeline([options], [callback]): [Promise]`: Starts recording allocation on heap. The valid options are:
 
   - `destination`: The path where to store the timeline. The default will be a `.heaptimeline` in the current directory.
   - `runGC`: If to run the garbage collector at the begining and the end of the timeline. The default is `false` and it is ignored if the process is not started with the `--expose-gc` flag.
+  - `duration`: Recording duration, in milliseconds. Default is `10000` (10 seconds), and it is ignored if `signal` is provided.
+  - `signal`: The [AbortController](http://npm.im/abort-controller) `signal` to use to stop the operation.
 
-  When using callback-style, call the returned function to stop recording allocation, and generate the output file:
-
-  ```js
-  const stop = recordAllocationTimeline(options, err => {
-    /* handle start errors */
-  })
-  // later on...
-  stop(err => {
-    /* handle stop errors, and use the file */
-  })
-  ```
-
-  When using promise-style, the returned promise will resolve with an async function for the same purposes:
-
-  ```js
-  const stop = await recordAllocationTimeline(options)
-  // catch any start error
-  // later on...
-  await stop()
-  // catch any stop errors, and use the file
-  ```
+  The function accepts a callback function, otherwise it returns a Promise. The resolved value (or the callback argument) will be
+  the generated file path.
 
 ## Performance impact
 
 Generating a heap dump snapshot is handled synchronously by Node and therefore **will block your process completely**.
 
-Generating a heap sampling profile is instead asynchronous and lightweight. Our test showed that the **performance decrease is around 10%**.
+Generating a heap sampling profile or record allocation timeline is instead asynchronous and lightweight. Our test showed that the **performance decrease is around 10%**.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/heap-profiler",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "Heap dump, sample profiler and allocation timeline generator for Node.",
   "author": "NearForm Ltd",
   "homepage": "https://github.com/nearform/heap-profiler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/heap-profiler",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Heap dump, sample profiler and allocation timeline generator for Node.",
   "author": "NearForm Ltd",
   "homepage": "https://github.com/nearform/heap-profiler",

--- a/src/preloader.js
+++ b/src/preloader.js
@@ -48,10 +48,6 @@ module.exports = function installPreloader(logger) {
       profilerOptions.interval = parseInt(process.env.HEAP_PROFILER_PROFILE_INTERVAL, 10)
     }
 
-    if ('HEAP_PROFILER_PROFILE_DURATION' in process.env) {
-      profilerOptions.duration = parseInt(process.env.HEAP_PROFILER_PROFILE_DURATION, 10) || 10000 // 10s
-    }
-
     if ('HEAP_PROFILER_TIMELINE_DESTINATION' in process.env) {
       timelineOptions.destination = process.env.HEAP_PROFILER_TIMELINE_DESTINATION
     }
@@ -93,8 +89,9 @@ module.exports = function installPreloader(logger) {
       profilerOptions.signal = controller.signal
       const abort = controller.abort.bind(controller)
       process.once('SIGUSR2', abort)
-      // logger.info(`[@nearform/heap-profiler] Sampling profiler started. Awaiting ${profilerOptions.duration} ms or SIGUSR2 to stop ...`)
-      benchmarkGeneration(logger, 'sampling profile', generateHeapSamplingProfile, profilerOptions, function (err) {
+
+      logger.info('[@nearform/heap-profiler] Sampling profiler started. Awaiting SIGUSR2 to stop ...')
+      benchmarkGeneration(logger, 'sampling profile', generateHeapSamplingProfile, profilerOptions, function(err) {
         process.removeListener('SIGUSR2', abort)
         onToolEnd(err)
       })

--- a/src/profile.js
+++ b/src/profile.js
@@ -37,8 +37,7 @@ module.exports = function generateHeapSamplingProfile(options, cb) {
 
   if (signal) {
     if (signal.aborted) {
-      callback(new Error('aborted'))
-      return
+      throw new Error('The AbortController has already been aborted')
     }
     if (signal.addEventListener) {
       signal.addEventListener('abort', finish)
@@ -47,7 +46,7 @@ module.exports = function generateHeapSamplingProfile(options, cb) {
     }
   }
 
-  function finish () {
+  function finish() {
     clearTimeout(timeout)
     session.post('HeapProfiler.stopSampling', (err, profile) => {
       /* istanbul ignore if */
@@ -83,7 +82,9 @@ module.exports = function generateHeapSamplingProfile(options, cb) {
         return callback(err)
       }
 
-      timeout = setTimeout(finish, duration)
+      if (!signal) {
+        timeout = setTimeout(finish, duration)
+      }
     })
   })
 

--- a/src/profile.js
+++ b/src/profile.js
@@ -24,21 +24,26 @@ module.exports = function generateHeapSamplingProfile(options, cb) {
   let timeout
 
   if (typeof destination !== 'string' || destination.length === 0) {
-    throw new Error('The destination option must be a non empty string')
+    callback(new Error('The destination option must be a non empty string'))
+    return
   }
 
   if (typeof duration !== 'number' || isNaN(duration) || duration < 0) {
-    throw new Error('The duration option must be a number greater than 0')
+    callback(new Error('The duration option must be a number greater than 0'))
+    return
   }
 
   if (typeof interval !== 'number' || isNaN(interval) || interval < 0) {
-    throw new Error('The interval option must be a number greater than 0')
+    callback(new Error('The interval option must be a number greater than 0'))
+    return
   }
 
   if (signal) {
     if (signal.aborted) {
-      throw new Error('The AbortController has already been aborted')
+      callback(new Error('The AbortController has already been aborted'))
+      return
     }
+
     if (signal.addEventListener) {
       signal.addEventListener('abort', finish)
     } else {

--- a/test/preloader.spec.js
+++ b/test/preloader.spec.js
@@ -12,7 +12,7 @@ const validateProfile = require('./fixtures/profileSchema')
 const sleep = promisify(setTimeout)
 const logger = { info: spy(), error: spy() }
 
-require('../src/preloader')(logger)
+const preloader = require('../src/preloader')
 
 function cleanEnvironment() {
   for (const key of [
@@ -22,7 +22,6 @@ function cleanEnvironment() {
     'HEAP_PROFILER_SNAPSHOT_DESTINATION',
     'HEAP_PROFILER_PROFILE',
     'HEAP_PROFILER_PROFILE_DESTINATION',
-    'HEAP_PROFILER_PROFILE_DURATION',
     'HEAP_PROFILER_PROFILE_INTERVAL',
     'HEAP_PROFILER_TIMELINE',
     'HEAP_PROFILER_TIMELINE_DESTINATION',
@@ -36,6 +35,11 @@ function cleanEnvironment() {
   logger.error.resetHistory()
 }
 
+function startPreloader() {
+  process.removeAllListeners('SIGUSR2')
+  preloader(logger)
+}
+
 async function waitForReport(spy, calls, timeout) {
   const startTime = process.hrtime.bigint()
 
@@ -44,8 +48,13 @@ async function waitForReport(spy, calls, timeout) {
   }
 }
 
-t.test('it correctly generates reports when receiving USR2 and stop the second time', async t => {
+t.beforeEach(done => {
   cleanEnvironment()
+  startPreloader()
+  done()
+})
+
+t.test('it correctly generates reports when receiving USR2 and stop the second time', async t => {
   const snapshotDestination = await tmpName()
   const profileDestination = await tmpName()
   const timelineDestination = await tmpName()
@@ -54,7 +63,6 @@ t.test('it correctly generates reports when receiving USR2 and stop the second t
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = snapshotDestination
   process.env.HEAP_PROFILER_SNAPSHOT_RUN_GC = 'true'
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = profileDestination
-  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_PROFILE_INTERVAL = 32768
   process.env.HEAP_PROFILER_TIMELINE_DESTINATION = timelineDestination
   process.env.HEAP_PROFILER_TIMELINE_RUN_GC = 'true'
@@ -63,12 +71,12 @@ t.test('it correctly generates reports when receiving USR2 and stop the second t
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 4, 10)
+  await waitForReport(logger.info, 4, 15)
   t.equal(logger.info.callCount, 4)
-  // stop timeline
+  // Stop timeline and profiler
   process.kill(process.pid, 'SIGUSR2')
-  await waitForReport(logger.info, 6, 10)
-  t.equal(logger.info.callCount, 6)
+  await waitForReport(logger.info, 8, 15)
+  t.equal(logger.info.callCount, 8)
 
   const generatedSnapshot = JSON.parse(readFileSync(snapshotDestination, 'utf-8'))
   const generatedProfile = JSON.parse(readFileSync(profileDestination, 'utf-8'))
@@ -91,7 +99,6 @@ t.test('it correctly generates reports when receiving USR2 and stop the second t
 })
 
 t.test('it correctly exclude reports based on environment variables', async t => {
-  cleanEnvironment()
   const snapshotDestination = await tmpName()
   const profileDestination = await tmpName()
   const timelineDestination = await tmpName()
@@ -107,10 +114,11 @@ t.test('it correctly exclude reports based on environment variables', async t =>
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 2, 10)
+  await waitForReport(logger.info, 3, 10)
 
   // Check the reports were never invoked
-  t.equal(logger.info.callCount, 2)
+  t.equal(logger.info.callCount, 3)
+
   t.throws(() => statSync(snapshotDestination), {
     message: `ENOENT: no such file or directory, stat '${snapshotDestination}'`
   })
@@ -127,33 +135,36 @@ t.test('it should run continuously', async t => {
   const profileDestination = await tmpName()
 
   // Set preloader variables
-  cleanEnvironment()
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = snapshotDestination
   process.env.HEAP_PROFILER_PROFILE = 'false'
   process.env.HEAP_PROFILER_TIMELINE = 'false'
 
-  // first snapshot
+  // first run - snapshot only
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 3, 10)
-  t.equal(logger.info.callCount, 3)
+  await waitForReport(logger.info, 4, 10)
+  t.equal(logger.info.callCount, 4)
 
   // Set preloader variables
   cleanEnvironment()
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = profileDestination
-  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_SNAPSHOT = 'false'
   process.env.HEAP_PROFILER_TIMELINE = 'false'
 
-  // second snapshot
+  // second run - profile only
+  process.kill(process.pid, 'SIGUSR2')
+
+  await sleep(100)
+
+  // stop the run
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 3, 10)
+  await waitForReport(logger.info, 4, 10)
 
   // Check the report was generated
-  t.equal(logger.info.callCount, 3)
+  t.equal(logger.info.callCount, 4)
 
   try {
     unlinkSync(snapshotDestination)
@@ -164,8 +175,6 @@ t.test('it should run continuously', async t => {
 })
 
 t.test('it should run continuously even when all tools are disabled', async t => {
-  cleanEnvironment()
-
   // Set preloader variables
   process.env.HEAP_PROFILER_SNAPSHOT = 'false'
   process.env.HEAP_PROFILER_PROFILE = 'false'
@@ -175,35 +184,33 @@ t.test('it should run continuously even when all tools are disabled', async t =>
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 2, 10)
-  t.equal(logger.info.callCount, 2)
+  await waitForReport(logger.info, 3, 10)
+  t.equal(logger.info.callCount, 3)
 
   // second snapshot
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
-  await waitForReport(logger.info, 4, 10)
+  await waitForReport(logger.info, 5, 10)
 
   // Check the report was generated
-  t.equal(logger.info.callCount, 4)
+  t.equal(logger.info.callCount, 5)
 })
 
 t.test('it correctly logs generation errors', async t => {
-  cleanEnvironment()
-
   // Set preloader variables
   process.env.HEAP_PROFILER_SNAPSHOT_DESTINATION = '/this/doesnt/exists-1'
   process.env.HEAP_PROFILER_PROFILE_DESTINATION = '/this/doesnt/exists-2'
   process.env.HEAP_PROFILER_TIMELINE_DESTINATION = '/this/doesnt/exists-3'
-  process.env.HEAP_PROFILER_PROFILE_DURATION = 2
   process.env.HEAP_PROFILER_PROFILE_INTERVAL = 32768
 
   process.kill(process.pid, 'SIGUSR2')
 
   // Wait for generators time to finish
+  await waitForReport(logger.info, 5, 2)
   await waitForReport(logger.error, 3, 2)
 
   // Check the reports were not generated
-  t.equal(logger.info.callCount, 3)
+  t.equal(logger.info.callCount, 5)
   t.equal(logger.error.callCount, 3)
 })

--- a/test/profile.spec.js
+++ b/test/profile.spec.js
@@ -13,86 +13,14 @@ const validate = require('./fixtures/profileSchema')
 t.test('it correctly generates a profile using promises', async t => {
   const { path: destination, cleanup } = await tmpFile()
 
-  await Promise.all([generateHeapSamplingProfile({ destination, duration: 100 }), allocateMemoryFor(100)])
+  const samplingPromise = generateHeapSamplingProfile({ destination, duration: 100 })
+  await allocateMemoryFor(100)
+  await samplingPromise
 
   const generated = JSON.parse(readFileSync(destination, 'utf-8'))
 
   t.true(validate(generated))
-
-  cleanup()
-})
-
-t.test('it accepts abort controller', async t => {
-  const { path: destination, cleanup } = await tmpFile()
-  const controller = new AbortController()
-
-  const start = Date.now()
-
-  setTimeout(function() {
-    controller.abort()
-  }, 100)
-
-  await Promise.race([generateHeapSamplingProfile({ destination, signal: controller.signal }), allocateMemoryFor(1000)])
-
-  const end = Date.now()
-
-  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
-
-  t.is(end - start < 1000, true)
-  t.is(end - start >= 100, true)
-
-  t.true(validate(generated))
-
-  cleanup()
-})
-
-t.test('it ignores duration when using an abort controller', async t => {
-  const { path: destination, cleanup } = await tmpFile()
-  const controller = new AbortController()
-
-  const start = Date.now()
-
-  setTimeout(function() {
-    controller.abort()
-  }, 200)
-
-  await Promise.race([
-    generateHeapSamplingProfile({ destination, signal: controller.signal, duration: 100 }),
-    allocateMemoryFor(1000)
-  ])
-
-  const end = Date.now()
-
-  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
-
-  t.is(end - start < 1000, true)
-  t.is(end - start >= 200, true)
-
-  t.true(validate(generated))
-
-  cleanup()
-})
-
-t.test('it accepts an EventEmitter as AbortController', async t => {
-  const { path: destination, cleanup } = await tmpFile()
-  const controller = new EventEmitter()
-
-  const start = Date.now()
-
-  setTimeout(function() {
-    controller.emit('abort')
-  }, 100)
-
-  await Promise.race([generateHeapSamplingProfile({ destination, signal: controller }), allocateMemoryFor(1000)])
-
-  const end = Date.now()
-
-  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
-
-  t.is(end - start < 1000, true)
-  t.is(end - start >= 100, true)
-
-  t.true(validate(generated))
+  t.strictSame(validate.errors, null)
 
   cleanup()
 })
@@ -107,6 +35,8 @@ t.test('it correctly generates a profile using callbacks', async t => {
         cleanup()
 
         t.true(validate(generated))
+        t.strictSame(validate.errors, null)
+
         resolve()
       } catch (e) {
         reject(e)
@@ -132,31 +62,123 @@ t.test('it handles file saving errors using callbacks', t => {
   })
 })
 
+t.test('it can use an AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new AbortController()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.abort()
+  }, 100)
+
+  const samplingPromise = generateHeapSamplingProfile({ destination, signal: controller.signal })
+  await allocateMemoryFor(100)
+  await samplingPromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 1000, true)
+  t.is(end - start >= 100, true)
+
+  t.true(validate(generated))
+
+  cleanup()
+})
+
+t.test('it can use an EventEmitter as AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new EventEmitter()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.emit('abort')
+  }, 100)
+
+  const samplingPromise = generateHeapSamplingProfile({ destination, signal: controller })
+  await allocateMemoryFor(100)
+  await samplingPromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 1000, true)
+  t.is(end - start >= 100, true)
+
+  t.true(validate(generated))
+
+  cleanup()
+})
+
+t.test('it ignores duration when using an AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new AbortController()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.abort()
+  }, 200)
+
+  const samplingPromise = generateHeapSamplingProfile({ destination, signal: controller.signal, duration: 100 })
+  await allocateMemoryFor(100)
+  await samplingPromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 1000, true)
+  t.is(end - start >= 200, true)
+
+  t.true(validate(generated))
+
+  cleanup()
+})
+
 t.test('it validates the destination option', t => {
-  t.throws(() => generateHeapSamplingProfile({ destination: 1 }), 'The destination option must be a non empty string')
-  t.throws(() => generateHeapSamplingProfile({ destination: '' }), 'The destination option must be a non empty string')
-  t.end()
+  t.plan(2)
+
+  generateHeapSamplingProfile({ destination: '' }, err => {
+    t.is(err.message, 'The destination option must be a non empty string')
+  })
+
+  generateHeapSamplingProfile({ destination: -1 }, err => {
+    t.is(err.message, 'The destination option must be a non empty string')
+  })
 })
 
 t.test('it validates the duration option', t => {
-  t.throws(() => generateHeapSamplingProfile({ duration: '' }), 'The duration option must be a number greater than 0')
-  t.throws(() => generateHeapSamplingProfile({ duration: -1 }), 'The duration option must be a number greater than 0')
-  t.end()
+  t.plan(2)
+
+  generateHeapSamplingProfile({ duration: '' }, err => {
+    t.is(err.message, 'The duration option must be a number greater than 0')
+  })
+
+  generateHeapSamplingProfile({ duration: -1 }, err => {
+    t.is(err.message, 'The duration option must be a number greater than 0')
+  })
 })
 
 t.test('it validates the interval option', t => {
-  t.throws(() => generateHeapSamplingProfile({ interval: '' }), 'The interval option must be a number greater than 0')
-  t.throws(() => generateHeapSamplingProfile({ interval: -1 }), 'The interval option must be a number greater than 0')
-  t.end()
+  t.plan(2)
+
+  generateHeapSamplingProfile({ interval: '' }, err => {
+    t.is(err.message, 'The interval option must be a number greater than 0')
+  })
+
+  generateHeapSamplingProfile({ interval: -1 }, err => {
+    t.is(err.message, 'The interval option must be a number greater than 0')
+  })
 })
 
 t.test('it validates the signal option', t => {
   const controller = new AbortController()
   controller.abort()
 
-  t.throws(
-    () => generateHeapSamplingProfile({ signal: controller.signal }),
-    'The AbortController has already been aborted'
-  )
-  t.end()
+  generateHeapSamplingProfile({ signal: controller.signal }, err => {
+    t.is(err.message, 'The AbortController has already been aborted')
+    t.end()
+  })
 })

--- a/test/timeline.spec.js
+++ b/test/timeline.spec.js
@@ -3,62 +3,74 @@
 const t = require('tap')
 const { readFileSync } = require('fs')
 const { file: tmpFile } = require('tmp-promise')
+const AbortController = require('abort-controller')
+const EventEmitter = require('events')
+
 const { stub } = require('sinon')
 
 const recordAllocationTimeline = require('../src/timeline')
+const allocateMemoryFor = require('./allocator')
 const validate = require('./fixtures/snapshotSchema')
-const wait = require('util').promisify(setTimeout)
-const duration = 10
-const timeout = 10000
 
-t.test('it correctly generates a timeline using promises', { timeout }, async t => {
+t.test('it correctly generates a timeline using promises', async t => {
   const { path: destination, cleanup } = await tmpFile()
 
-  const stop = await recordAllocationTimeline({ destination })
-  await wait(duration)
-  await stop()
+  const timelinePromise = recordAllocationTimeline({ destination, duration: 100 })
+  await allocateMemoryFor(100)
+  await timelinePromise
 
   const generated = JSON.parse(readFileSync(destination, 'utf-8'))
 
-  validate(generated)
+  t.true(validate(generated))
   t.strictSame(validate.errors, null)
   cleanup()
 })
 
-t.test('it correctly generates a timeline using callbacks', { timeout }, async t => {
+t.test('it correctly generates a timeline using callbacks', async t => {
   const { path: destination, cleanup } = await tmpFile()
 
-  return new Promise((resolve, reject) => {
-    const stop = recordAllocationTimeline({ destination }, (err) => {
-      if (err) {
-        return reject(err)
-      }
-    })
-    setTimeout(() => stop((err) => {
-      if (err) {
-        return reject(err)
-      }
+  const test = new Promise((resolve, reject) => {
+    recordAllocationTimeline({ destination, duration: 100 }, () => {
       try {
         const generated = JSON.parse(readFileSync(destination, 'utf-8'))
         cleanup()
-        validate(generated)
+
+        t.true(validate(generated))
         t.strictSame(validate.errors, null)
+
         resolve()
       } catch (e) {
         reject(e)
       }
-    }), duration)
+    })
+  })
+
+  await allocateMemoryFor(100)
+
+  return test
+})
+
+t.test('it handles file saving errors using promises', async t => {
+  await t.rejects(recordAllocationTimeline({ destination: '/this/doesnt/exists' }), {
+    message: "ENOENT: no such file or directory, open '/this/doesnt/exists'"
   })
 })
 
-t.test('it runs the garbage collector if requested to', { timeout }, async t => {
+t.test('it handles file saving errors using callbacks', t => {
+  recordAllocationTimeline({ destination: '/this/doesnt/exists' }, err => {
+    t.equal(err.message, "ENOENT: no such file or directory, open '/this/doesnt/exists'")
+    t.end()
+  })
+})
+
+t.test('it runs the garbage collector if requested to', async t => {
   const gcStub = stub(global, 'gc')
 
   const { path: destination, cleanup } = await tmpFile()
 
-  const stop = await recordAllocationTimeline({ destination, runGC: true })
-  await wait(duration)
-  await stop()
+  const timelinePromise = recordAllocationTimeline({ destination, runGC: true, duration: 100 })
+  await allocateMemoryFor(100)
+  await timelinePromise
 
   const generated = JSON.parse(readFileSync(destination, 'utf-8'))
 
@@ -76,7 +88,8 @@ t.test('it handles garbage collector error before recording', async t => {
   const { path: destination, cleanup } = await tmpFile()
 
   try {
-    await recordAllocationTimeline({ destination, runGC: true })
+    await recordAllocationTimeline({ destination, runGC: true, duration: 100 })
+
     t.fail('DID NOT THROW')
   } catch (e) {
     t.equal(e.message, 'FAILED')
@@ -93,10 +106,9 @@ t.test('it handles garbage collector error when stopping recording', async t => 
   gcStub.onSecondCall().throws(new Error('FAILED'))
   const { path: destination, cleanup } = await tmpFile()
 
-  const stop = await recordAllocationTimeline({ destination, runGC: true })
-  await wait(duration)
   try {
-    await stop()
+    await recordAllocationTimeline({ destination, runGC: true, duration: 100 })
+
     t.fail('DID NOT THROW')
   } catch (e) {
     t.equal(e.message, 'FAILED')
@@ -108,21 +120,111 @@ t.test('it handles garbage collector error when stopping recording', async t => 
   gcStub.restore()
 })
 
-t.test('it handles file saving errors using promises', async t => {
-  await t.rejects(recordAllocationTimeline({ destination: '/this/doesnt/exists' }), {
-    message: "ENOENT: no such file or directory, open '/this/doesnt/exists'"
-  })
+t.test('it can use an AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new AbortController()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.abort()
+  }, 100)
+
+  const timelinePromise = recordAllocationTimeline({ destination, signal: controller.signal })
+  await allocateMemoryFor(100)
+  await timelinePromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 5000, true)
+  t.is(end - start >= 100, true)
+
+  t.true(validate(generated))
+
+  cleanup()
 })
 
-t.test('it handles file saving errors using callbacks', t => {
-  recordAllocationTimeline({ destination: '/this/doesnt/exists' }, err => {
-    t.equal(err.message, "ENOENT: no such file or directory, open '/this/doesnt/exists'")
-    t.end()
-  })
+t.test('it can use an EventEmitter as AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new EventEmitter()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.emit('abort')
+  }, 100)
+
+  const timelinePromise = recordAllocationTimeline({ destination, signal: controller })
+  await allocateMemoryFor(100)
+  await timelinePromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 5000, true)
+  t.is(end - start >= 100, true)
+
+  t.true(validate(generated))
+
+  cleanup()
+})
+
+t.test('it ignores duration when using an AbortController', async t => {
+  const { path: destination, cleanup } = await tmpFile()
+  const controller = new AbortController()
+
+  const start = Date.now()
+
+  setTimeout(function() {
+    controller.abort()
+  }, 200)
+
+  const timelinePromise = recordAllocationTimeline({ destination, signal: controller.signal, duration: 100 })
+  await allocateMemoryFor(100)
+  await timelinePromise
+
+  const end = Date.now()
+  const generated = JSON.parse(readFileSync(destination, 'utf-8'))
+
+  t.is(end - start < 5000, true)
+  t.is(end - start >= 200, true)
+
+  t.true(validate(generated))
+
+  cleanup()
 })
 
 t.test('it validates the destination option', t => {
-  t.throws(() => recordAllocationTimeline({ destination: 1 }), 'The destination option must be a non empty string')
-  t.throws(() => recordAllocationTimeline({ destination: '' }), 'The destination option must be a non empty string')
-  t.end()
+  t.plan(2)
+
+  recordAllocationTimeline({ destination: '' }, err => {
+    t.is(err.message, 'The destination option must be a non empty string')
+  })
+
+  recordAllocationTimeline({ destination: -1 }, err => {
+    t.is(err.message, 'The destination option must be a non empty string')
+  })
+})
+
+t.test('it validates the duration option', t => {
+  t.plan(2)
+
+  recordAllocationTimeline({ duration: '' }, err => {
+    t.is(err.message, 'The duration option must be a number greater than 0')
+  })
+
+  recordAllocationTimeline({ duration: -1 }, err => {
+    t.is(err.message, 'The duration option must be a number greater than 0')
+  })
+})
+
+t.test('it validates the signal option', t => {
+  const controller = new AbortController()
+  controller.abort()
+
+  recordAllocationTimeline({ signal: controller.signal }, err => {
+    t.is(err.message, 'The AbortController has already been aborted')
+    t.end()
+  })
 })


### PR DESCRIPTION
## What's in there

This PR streamlines heap sampling profiler and allocation time to both use AbortController.
The two tools now share most of the code so in the future we might also think to refactor them to avoid duplication.

Additionally, the `duration` option (which is now available even for allocation timeline) is ignored if a signal is provided.