### PR TITLE
fix: Add a flag to disabled the preloader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Then the tool will await on the next signal, to resume profiling/tracking/shooti
 
 The preloader uses the following environment variables to control its behavior:
 
+- `HEAP_PROFILER_PRELOADER_DISABLED`: If set to `true`, the preloader is not installed and you need to use the API to sample the process.
+
 - `HEAP_PROFILER_SNAPSHOT`: If set to `false`, it will not generate heap dump snapshots.
 
 - `HEAP_PROFILER_SNAPSHOT_DESTINATION`: The path where to store the snapshot. The default will be a `.heapsnapshot` in the current directory.

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const generateHeapSamplingProfile = require('./profile')
 
 module.exports = { generateHeapSnapshot, generateHeapSamplingProfile }
 
-if (require.main === undefined) {
+if (process.env.HEAP_PROFILER_PRELOADER_DISABLED !== 'true' && require.main === undefined) {
   let logger = console
 
   if (process.env.HEAP_PROFILER_LOGGING_DISABLED === 'true') {


### PR DESCRIPTION
## What's in there?

When invoked in a script which is included via `node -r` (like `node -r script.js app.js`) the preloader is installed due to `require.main` being null.

This PR adds support `HEAP_PROFILER_PRELOADER_DISABLED` to always skip the automatic loading of the preloader.