### PR TITLE
fix: make writeFile sync on finish

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Session } = require('inspector')
-const { writeFile } = require('fs')
+const { writeFileSync } = require('fs')
 const { ensurePromiseCallback, destinationFile, validateDestinationFile } = require('./utils')
 
 const defaultInterval = 32768
@@ -61,14 +61,12 @@ module.exports = function generateHeapSamplingProfile(options, cb) {
 
       session.disconnect()
 
-      writeFile(destination, JSON.stringify(profile.profile), 'utf-8', err => {
-        /* istanbul ignore if */
-        if (err) {
-          return callback(err)
-        }
-
+      try {
+        writeFileSync(destination, JSON.stringify(profile.profile), 'utf-8')
         callback(null, destination)
-      })
+      } catch (err) {
+        callback(err)
+      }
     })
   }
 


### PR DESCRIPTION
I'm investigating on [this issue](https://github.com/clinicjs/node-clinic/issues/463) on the node-clinic repo. 

Basically, when the script calls `process.exit(0)`, the profile file is not written. The file is created but internally it is empty. Changing the writeFile to its synchronous version is fixing this issue locally

